### PR TITLE
Update Util.php

### DIFF
--- a/inc/WPENC/Core/Util.php
+++ b/inc/WPENC/Core/Util.php
@@ -297,10 +297,10 @@ if ( ! class_exists( 'WPENC\Core\Util' ) ) {
 
 			foreach ( $addon_domains as $addon_domain ) {
 				$all_domains[] = $addon_domain;
-				if ( 1 === substr_count( $addon_domain, '.' ) ) {
-					$all_domains[] = 'www.' . $addon_domain;
-				} elseif ( 2 === substr_count( $addon_domain, '.' ) && 'www.' === substr( $addon_domain, 0, 4 ) ) {
+				if('www.' === substr( $addon_domain, 0, 4 ) ) {
 					$all_domains[] = substr( $addon_domain, 4 );
+				} else {
+					$all_domains[] = 'www.' . $addon_domain;
 				}
 			}
 


### PR DESCRIPTION
Fix to function get_all_domains.
Fixes issue #33 https://github.com/felixarntz/wp-encrypt/issues/33
Where the function now returns correctly for domains with more than one dot e.g. example.co.uk

Tested with a number of alternatives, see: http://sandbox.onlinephpfunctions.com/code/4aa300db95b930e50cbc99deaec7f49112750e6b